### PR TITLE
Add Docker support: Dockerfile and requirements.txt

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.env
+.venv/
+*.db
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src src
+
+CMD ["uvicorn", "src.fast_api_example.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+pydantic
+uvicorn


### PR DESCRIPTION
# Add Dockerfile and requirements.txt for FastAPI example

## Summary
- `Dockerfile` to run the FastAPI app in a container
-  `requirements.txt` listing all python dependencies 

### Build and run the container:

```bash
docker build -t fastapi_example .
docker run -p 8000:8000 fastapi_example
```
 just open localhost on port 8000